### PR TITLE
Resolve issues with actor duplication

### DIFF
--- a/module/chat_messages.js
+++ b/module/chat_messages.js
@@ -1,4 +1,4 @@
-import {findActorFromItemId, generateDieRollFormula, interpolate} from './shared.js';
+import {generateDieRollFormula, interpolate} from './shared.js';
 
 function isRollCritical(roll, options={}) {
     let outcome = false;
@@ -162,9 +162,7 @@ export function logDamageRoll(event) {
     return(false);
 }
 
-export function logUsageDieRoll(itemId) {
-    let actor = findActorFromItemId(itemId);
-
+export function logUsageDieRoll(actor, itemId) {
     if(actor) {
         let item = actor.items.find(i => i.id === itemId);
 

--- a/module/magic.js
+++ b/module/magic.js
@@ -1,9 +1,8 @@
-import {findActorFromItemId, generateDieRollFormula, interpolate} from './shared.js';
+import {generateDieRollFormula, interpolate} from './shared.js';
 import {showMessage} from './chat_messages.js';
 
-export function castMagic(event) {
+export function castMagic(event, actor) {
     let element = event.currentTarget;
-    let actor   = findActorFromItemId(element.dataset.id);
 
     event.preventDefault();
     event.stopPropagation();
@@ -43,9 +42,8 @@ export function castMagic(event) {
     return(false);
 }
 
-export function castMagicAsRitual(event) {
+export function castMagicAsRitual(event, actor) {
     let element = event.currentTarget;
-    let actor   = findActorFromItemId(element.dataset.id);
 
     event.preventDefault();
     event.stopPropagation();
@@ -119,9 +117,8 @@ function invokeMagic(magicId, caster) {
             }));
 }
 
-export function prepareMagic(event) {
+export function prepareMagic(event, actor) {
     let element = event.currentTarget;
-    let actor   = findActorFromItemId(element.dataset.id);
 
     event.preventDefault();
     event.stopPropagation();
@@ -138,9 +135,8 @@ export function prepareMagic(event) {
 }
 
 
-export function unprepareMagic(event) {
+export function unprepareMagic(event, actor) {
     let element = event.currentTarget;
-    let actor   = findActorFromItemId(element.dataset.id);
 
     event.preventDefault();
     event.stopPropagation();

--- a/module/shared.js
+++ b/module/shared.js
@@ -1,40 +1,4 @@
 /**
- * Deletes an owned item from an actor using just the item id to locate the
- * owning actor and the item itself.
- */
-export function deleteOwnedItem(itemId) {
-    console.log(`Delete of item id ${itemId} requested.`);
-    let actor = findActorFromItemId(itemId);
-
-    if(actor) {
-        actor.deleteEmbeddedDocuments("Item", [itemId]);
-    } else {
-        console.error(`Delete of item id ${itemId} requested but unable to locate the actor that owns it.`);
-    }
-}
-
-/**
- * Searches the game actor list to locate the actor that owns an item with a
- * specified itemId.
- */
-export function findActorFromItemId(itemId) {
-  return(game.actors.find((a) => {
-        if(a.items.find(i => i.id === itemId)) {
-          return(true);
-        } else {
-          return(false);
-        }
-      }));
-}
-
-/**
- * Searches the game item list to a specific item.
- */
-export function findItemFromId(itemId) {
-    return(game.items.find((item) => item.id === itemId));
-}
-
-/**
  * Generates a string containing the formula for a single die based on the set
  * of options passed in. Recognised options include dieType, which defaults to
  * d20 if not set, and kind which should be one of 'standard', 'advantage' or

--- a/module/sheets/BH2eCharacterSheet.js
+++ b/module/sheets/BH2eCharacterSheet.js
@@ -233,7 +233,7 @@ export default class BH2eCharacterSheet extends ActorSheet {
         return(false);
     }
 
-    _onDecreaseEquipmentQuantityClicked(evemt) {
+    _onDecreaseEquipmentQuantityClicked(event) {
         let element = event.currentTarget;
 
         event.preventDefault();
@@ -251,7 +251,7 @@ export default class BH2eCharacterSheet extends ActorSheet {
         return(false);
     }
 
-    _onIncreaseEquipmentQuantityClicked(evemt) {
+    _onIncreaseEquipmentQuantityClicked(event) {
         let element = event.currentTarget;
 
         event.preventDefault();

--- a/module/sheets/BH2eCharacterSheet.js
+++ b/module/sheets/BH2eCharacterSheet.js
@@ -4,9 +4,7 @@ import {castMagic,
         castMagicAsRitual,
         prepareMagic,
         unprepareMagic} from '../magic.js';
-import {deleteOwnedItem,
-        findActorFromItemId,
-        generateDieRollFormula,
+import {generateDieRollFormula,
         initializeCharacterSheetUI,
         interpolate,
         onTabSelected} from '../shared.js';
@@ -59,10 +57,10 @@ export default class BH2eCharacterSheet extends ActorSheet {
         html.find(".bh2e-reset-usage-die-icon").click(this._onResetUsageDieClicked.bind(this));
         html.find(".bh2e-increase-quantity-icon").click(this._onIncreaseEquipmentQuantityClicked.bind(this));
         html.find(".bh2e-decrease-quantity-icon").click(this._onDecreaseEquipmentQuantityClicked.bind(this));
-        html.find(".bh2e-cast-magic-icon").click(castMagic);
-        html.find(".bh2e-cast-magic-as-ritual-icon").click(castMagicAsRitual);
-        html.find(".bh2e-prepare-magic-icon").click(prepareMagic);
-        html.find(".bh2e-unprepare-magic-icon").click(unprepareMagic);
+        html.find(".bh2e-cast-magic-icon").click((e) => castMagic(e, this.actor));
+        html.find(".bh2e-cast-magic-as-ritual-icon").click((e) => castMagicAsRitual(e, this.actor));
+        html.find(".bh2e-prepare-magic-icon").click((e) => prepareMagic(e, this.actor));
+        html.find(".bh2e-unprepare-magic-icon").click((e) => unprepareMagic(e, this.actor));
         html.find(".bh2e-info-element").click((e) => InfoDialog.build(e.currentTarget).then((d) => d.render(true)));
     }
 
@@ -194,7 +192,7 @@ export default class BH2eCharacterSheet extends ActorSheet {
         event.preventDefault();
         if(element.dataset.id) {
             console.log(`Breakage of armour die on armour item id ${element.dataset.id}.`);
-            let actor = findActorFromItemId(element.dataset.id);
+            let actor = this.actor;
             if(actor) {
                 let item  = actor.items.find(i => i.id === element.dataset.id);
 
@@ -238,7 +236,7 @@ export default class BH2eCharacterSheet extends ActorSheet {
 
         event.preventDefault();
         if(element.dataset.id) {
-            let actor = findActorFromItemId(element.dataset.id);
+            let actor = this.actor;
 
             if(actor) {
                 this.decrementEquipmentQuantity(actor, element.dataset.id)
@@ -256,7 +254,7 @@ export default class BH2eCharacterSheet extends ActorSheet {
 
         event.preventDefault();
         if(element.dataset.id) {
-            let actor = findActorFromItemId(element.dataset.id);
+            let actor = this.actor;
             if(actor) {
                 this.incrementEquipmentQuantity(actor, element.dataset.id)
             } else {
@@ -297,7 +295,7 @@ export default class BH2eCharacterSheet extends ActorSheet {
         event.preventDefault();
         if(element.dataset.id) {
             console.log(`Repairing of armour die on armour item id ${element.dataset.id}.`);
-            let actor = findActorFromItemId(element.dataset.id);
+            let actor = this.actor;
             if(actor) {
                 let item  = actor.items.find(i => i.id === element.dataset.id);
 
@@ -348,7 +346,7 @@ export default class BH2eCharacterSheet extends ActorSheet {
 
         event.preventDefault();
         if(itemId) {
-            let actor = findActorFromItemId(itemId);
+            let actor = this.actor;
 
             if(actor) {
                 this.resetUsageDie(actor, itemId);
@@ -363,7 +361,7 @@ export default class BH2eCharacterSheet extends ActorSheet {
 
     _onRollAttackClicked(event) {
         let element = event.currentTarget;
-        let actor   = findActorFromItemId(element.dataset.id);
+        let actor   = this.actor;
 
         event.preventDefault();
         if(!event.altKey) {
@@ -388,7 +386,8 @@ export default class BH2eCharacterSheet extends ActorSheet {
         let element = event.currentTarget;
 
         event.preventDefault();
-        logUsageDieRoll(element.dataset.id);
+        let actor = this.actor
+        logUsageDieRoll(actor, element.dataset.id);
         return(false);
     }
 

--- a/module/sheets/BH2eCharacterSheet.js
+++ b/module/sheets/BH2eCharacterSheet.js
@@ -226,7 +226,7 @@ export default class BH2eCharacterSheet extends ActorSheet {
 
         event.preventDefault();
         if(element.dataset.id) {
-            deleteOwnedItem(element.dataset.id);
+            this.actor.deleteEmbeddedDocuments("Item", [element.dataset.id]);
         } else {
             console.error("Delete item called for but item id is not present on the element.");
         }

--- a/module/sheets/BH2eCreatureSheet.js
+++ b/module/sheets/BH2eCreatureSheet.js
@@ -28,7 +28,7 @@ export default class BH2eCreatureSheet extends ActorSheet {
         event.preventDefault();
         let element = event.currentTarget;
         if(element.dataset.id) {
-            deleteOwnedItem(element.dataset.id);
+            this.actor.deleteEmbeddedDocuments("Item", [element.dataset.id]);
         } else {
           console.error("Delete item called for but item id is not present on the element.");
         }

--- a/module/sheets/BH2eCreatureSheet.js
+++ b/module/sheets/BH2eCreatureSheet.js
@@ -1,5 +1,3 @@
-import {deleteOwnedItem} from '../shared.js';
-
 export default class BH2eCreatureSheet extends ActorSheet {
     static get defaultOptions() {
         return(mergeObject(super.defaultOptions,


### PR DESCRIPTION
This removes relying on the functions mentioned in #31 and uses the current actor object instead.  After some testing it seems to work though I'm not sure it is the best solution.

Other related issues with the character sheet that I'd also like to resolve in this pull but I need some direction of where to look to address them:
- Character sheet tabs not being instantiated which causes tabs on all sheets that are open to change when clicked.
- Clicking buttons on the character sheets (Damage, Repair, Break, Casting) seem to _sometimes_ cause a javascript failure that crashes the browser window.